### PR TITLE
WindowsCapability: Fix Set-TargetResource for Windows Capability

### DIFF
--- a/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
+++ b/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
@@ -102,19 +102,36 @@ function Set-TargetResource
     )
 
     Write-Verbose -Message ($script:localizedData.SetTargetResourceStartMessage -f $Name)
-
+    $PSBoundParameters.Remove('Ensure')
     $windowsCapability = Get-WindowsCapability -Online @PSBoundParameters
 
-    if ($PSBoundParameters.ContainsKey('Ensure') -and $Ensure -ne $ensureResult)
+    if ($windowsCapability.State -eq 'Installed')
     {
-        Write-Verbose -Message ($script:localizedData.SetTargetAddMessage -f $Name)
-        $null = Add-WindowsCapability -Online @PSBoundParameters
+        $ensureResult = 'Present'
+    }
+    else
+    {
+        $ensureResult = 'Absent'
     }
 
-    if ($PSBoundParameters.ContainsKey('Absent') -and $Ensure -ne $ensureResult)
+    switch ($Ensure)
     {
-        Write-Verbose -Message ($script:localizedData.SetTargetRemoveMessage -f $Name)
-        $null = Remove-WindowsCapability -Online @PSBoundParameters
+        'Present'
+        {
+            if ($Ensure -ne $ensureResult)
+            {
+                Write-Verbose -Message ($script:localizedData.SetTargetAddMessage -f $Name)
+                $null = Add-WindowsCapability -Online @PSBoundParameters
+            }
+        }
+        'Absent'
+        {
+            if ($Ensure -ne $ensureResult)
+            {
+                Write-Verbose -Message ($script:localizedData.SetTargetRemoveMessage -f $Name)
+                $null = Remove-WindowsCapability -Online @PSBoundParameters
+            }
+        }
     }
 }
 

--- a/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
+++ b/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
@@ -89,7 +89,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateSet('Errors', 'Warnings', 'WarningsInfo')]


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
The new resource has an issue if you like to disable a Windows Capability.

#### This Pull Request (PR) fixes the following issues
- Fixes an issue with Set-TargetResource 'Absent'

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
